### PR TITLE
Pin GitHub Actions to specific commit hashes

### DIFF
--- a/.github/workflows/windows-cmake-vcpkg.yml
+++ b/.github/workflows/windows-cmake-vcpkg.yml
@@ -33,10 +33,10 @@ jobs:
           # Do not use if not needed, since it slows down the checkout of sources.
           fetch-depth: 0
 
-      - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1
         id: runvcpkg
         with:
           # This one is not needed, as it is the default value anyway.
@@ -46,7 +46,7 @@ jobs:
       - name: Prints output of run-vcpkg's action.
         run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}' "
       - name: Run CMake+vcpkg+Ninja
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4
         id: runcmake
         with:
           cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'


### PR DESCRIPTION
Pin GitHub Actions to specific commit hashes

Updated `lukka/get-cmake`, `lukka/run-vcpkg`, and `lukka/run-cmake` actions to use specific commit hashes instead of floating versions (`@latest`, `@v11`, `@v10`). This change improves reproducibility, stability, and consistency in the workflow by avoiding potential issues caused by future updates to these actions. No functional changes were made to the workflow logic.