### PR TITLE
Lock cpp-linter-action to specific commit hash

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -14,7 +14,7 @@ jobs:
 
       # ... optionally setup build env to create a compilation database
 
-      - uses: cpp-linter/cpp-linter-action@v2
+      - uses: cpp-linter/cpp-linter-action@f91c446a32ae3eb9f98fef8c9ed4c7cb613a4f8a
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Lock cpp-linter-action to specific commit hash

Updated cpp-linter.yml to use commit hash f91c446a32ae3eb9f98fef8c9ed4c7cb613a4f8a
instead of the v2 tag for cpp-linter/cpp-linter-action. This change ensures
stability by preventing unexpected updates from future changes to the v2 tag.